### PR TITLE
change imports

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -3,7 +3,7 @@ package kingpin
 import (
 	"io/ioutil"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 
 	"sort"
 	"strings"

--- a/args_test.go
+++ b/args_test.go
@@ -2,10 +2,10 @@ package kingpin
 
 import (
 	"io/ioutil"
-	"testing"
 	"os"
+	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 )
 
 func TestArgRemainder(t *testing.T) {

--- a/cmd/genvalues/main.go
+++ b/cmd/genvalues/main.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 const (

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 
 	"testing"
 )

--- a/completions_test.go
+++ b/completions_test.go
@@ -3,7 +3,7 @@ package kingpin
 import (
 	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 )
 
 func TestResolveWithBuiltin(t *testing.T) {

--- a/flags_test.go
+++ b/flags_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 
 	"testing"
 )

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 )
 
 func TestParserExpandFromFile(t *testing.T) {

--- a/parsers_test.go
+++ b/parsers_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 
 	"testing"
 )

--- a/usage.go
+++ b/usage.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/alecthomas/template"
+	"text/template"
 )
 
 var (

--- a/usage_test.go
+++ b/usage_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 )
 
 func TestFormatTwoColumns(t *testing.T) {

--- a/values_test.go
+++ b/values_test.go
@@ -3,7 +3,7 @@ package kingpin
 import (
 	"net"
 
-	"github.com/alecthomas/assert"
+	"github.com/tj/assert"
 
 	"testing"
 )


### PR DESCRIPTION
github.com/alecthomas/template is really old and buggy and keeps getting imported on top of `text/template` and `html/template`. This replaces the import.

I also replaced `github.com/alecthomas/assert` with `github.com/tj/assert`. 

2 tests are failing, but they were failing before this change 😅 